### PR TITLE
Default dashboard_id and created_from in manual workflow inputs

### DIFF
--- a/.github/workflows/edesky-search.yml
+++ b/.github/workflows/edesky-search.yml
@@ -11,6 +11,7 @@ on:
         description: "Volitelně: ID úřední desky (Bílovice n. Sv. = 1061)"
         required: false
         type: string
+        default: "1061"
       search_with:
         description: "es = i skloňované tvary a obsah, sql = jen název"
         required: false
@@ -20,9 +21,10 @@ on:
           - sql
         default: es
       created_from:
-        description: "Jen dokumenty od tohoto data (YYYY-MM-DD). Bez zadání API vrací jen nedávné dokumenty — pro celou historii zadej např. 2000-01-01"
+        description: "Jen dokumenty od tohoto data (YYYY-MM-DD). Bez zadání API vrací jen nedávné dokumenty."
         required: false
         type: string
+        default: "2000-01-01"
 
 jobs:
   search:


### PR DESCRIPTION
## Summary
- Sets `dashboard_id` default to `1061` (Bílovice nad Svitavou) and `created_from` default to `2000-01-01` on the "Edesky search" workflow's manual inputs
- A run now searches the full history of that board out of the box, without needing to type both values in every time; either can still be overridden or cleared

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBXJZCVfw3XXR1phdVpiso)_