### PR TITLE
Add region search: fulltext scan across surrounding municipalities

### DIFF
--- a/.github/workflows/edesky-region-search.yml
+++ b/.github/workflows/edesky-region-search.yml
@@ -1,0 +1,54 @@
+name: Edesky region search
+
+on:
+  workflow_dispatch:
+    inputs:
+      anchor_dashboard_id:
+        description: "Kotevní deska — prohledá se okolí (obce se stejným administrativním rodičem)"
+        required: true
+        type: string
+        default: "1061"
+      kraj_id:
+        description: "ID kraje, ve kterém se dohledává rodič kotevní desky (Jihomoravský kraj = 32)"
+        required: false
+        type: string
+        default: "32"
+      words:
+        description: "Hledaná slova/tvary oddělené čárkou"
+        required: true
+        type: string
+        default: "Výleta,Výlety,Výletovi,Výletu,Výletou,Výletem"
+      created_from:
+        description: "Jen dokumenty od tohoto data (YYYY-MM-DD)"
+        required: false
+        type: string
+        default: "2000-01-01"
+      max_desek:
+        description: "Nejvýše kolik desek okolí prohledat"
+        required: false
+        type: string
+        default: "60"
+
+jobs:
+  region-search:
+    name: Fulltext search over surrounding dashboards
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Run region search
+        env:
+          EDESKY_API_KEY: ${{ secrets.EDESKY_API_KEY }}
+        run: |
+          python3 scripts/edesky_region_hledej.py \
+            --anchor-dashboard-id "${{ inputs.anchor_dashboard_id }}" \
+            --kraj-id "${{ inputs.kraj_id }}" \
+            --words "${{ inputs.words }}" \
+            --created-from "${{ inputs.created_from }}" \
+            --max-desek "${{ inputs.max_desek }}"

--- a/scripts/edesky_fulltext_hledej.py
+++ b/scripts/edesky_fulltext_hledej.py
@@ -63,6 +63,54 @@ def _najdi_useky(text, slovo, kontext=60):
     return useky
 
 
+def sken_desku(dashboard_id, broad_keywords, slova, api_key,
+               created_from="2000-01-01", search_with="es", stderr_prefix=""):
+    """
+    Stáhne seznam dokumentů jedné desky (přes broad_keywords) a ručně
+    prohledá jejich plný text (edesky_text_url) na zadaná slova.
+
+    Vrací (nalezeno, pocet_dokumentu, pocet_bez_textu, chyba_seznamu), kde
+    nalezeno je seznam (nazev, datum, url, zasahy) a chyba_seznamu je None
+    nebo chybová hláška ze stahování seznamu dokumentů (i při chybě může
+    nalezeno obsahovat výsledky z částečně staženého seznamu).
+    """
+    dokumenty, chyba = stahni_vse(broad_keywords, api_key, dashboard_id,
+                                   search_with, "date", created_from)
+    dokumenty = _dedup(dokumenty)
+
+    nalezeno = []
+    chybely_text = 0
+    for i, d in enumerate(dokumenty, 1):
+        nazev = _first(d, ["name", "title"]) or "(bez názvu)"
+        text_url = _first(d, ["edesky_text_url"])
+        edesky_url = _first(d, ["edesky_url", "url"])
+        datum = _first(d, ["created_at", "edited_date", "created_date", "date"])
+
+        if not text_url:
+            chybely_text += 1
+            continue
+
+        text, chyba_t = stahni(text_url)
+        time.sleep(SLEEP_MEZI_DOTAZY_S)
+        if chyba_t or text is None:
+            print("%s  [%d/%d] %s — nelze stáhnout text (%s)" %
+                  (stderr_prefix, i, len(dokumenty), nazev, chyba_t), file=sys.stderr)
+            continue
+
+        zasahy = {}
+        for slovo in slova:
+            useky = _najdi_useky(text, slovo)
+            if useky:
+                zasahy[slovo] = useky
+
+        if zasahy:
+            nalezeno.append((nazev, datum, edesky_url, zasahy))
+            print("%s  [%d/%d] SHODA: %s" % (stderr_prefix, i, len(dokumenty), nazev),
+                  file=sys.stderr)
+
+    return nalezeno, len(dokumenty), chybely_text, chyba
+
+
 def main(argv=None):
     p = argparse.ArgumentParser(description="Fulltextové prohledání všech dokumentů desky.")
     p.add_argument("--api-key", default=os.environ.get("EDESKY_API_KEY"))
@@ -85,49 +133,17 @@ def main(argv=None):
 
     print("Stahuji seznam dokumentů desky %s (broad-keywords=%r, created_from=%s)..."
           % (args.dashboard_id, args.broad_keywords, args.created_from), file=sys.stderr)
-    dokumenty, chyba = stahni_vse(args.broad_keywords, args.api_key, args.dashboard_id,
-                                   args.search_with, "date", args.created_from)
+    nalezeno, pocet_dok, chybely_text, chyba = sken_desku(
+        args.dashboard_id, args.broad_keywords, slova, args.api_key,
+        args.created_from, args.search_with)
     if chyba:
         print("CHYBA při stahování seznamu: %s" % chyba, file=sys.stderr)
-        if not dokumenty:
-            return 1
-
-    dokumenty = _dedup(dokumenty)
-    print("Nalezeno %d unikátních dokumentů k prohledání.\n" % len(dokumenty), file=sys.stderr)
-
-    nalezeno = []
-    chybely_text = 0
-    for i, d in enumerate(dokumenty, 1):
-        nazev = _first(d, ["name", "title"]) or "(bez názvu)"
-        text_url = _first(d, ["edesky_text_url"])
-        edesky_url = _first(d, ["edesky_url", "url"])
-        datum = _first(d, ["created_at", "edited_date", "created_date", "date"])
-
-        if not text_url:
-            chybely_text += 1
-            continue
-
-        text, chyba_t = stahni(text_url)
-        time.sleep(SLEEP_MEZI_DOTAZY_S)
-        if chyba_t or text is None:
-            print("  [%d/%d] %s — nelze stáhnout text (%s)" %
-                  (i, len(dokumenty), nazev, chyba_t), file=sys.stderr)
-            continue
-
-        zasahy = {}
-        for slovo in slova:
-            useky = _najdi_useky(text, slovo)
-            if useky:
-                zasahy[slovo] = useky
-
-        if zasahy:
-            nalezeno.append((nazev, datum, edesky_url, zasahy))
-            print("  [%d/%d] SHODA: %s" % (i, len(dokumenty), nazev), file=sys.stderr)
+    print("Nalezeno %d unikátních dokumentů k prohledání.\n" % pocet_dok, file=sys.stderr)
 
     print("\n" + "=" * 60)
     if not nalezeno:
         print("Ve fulltextu žádného z %d dokumentů nebyla nalezena žádná ze zadaných forem: %s"
-              % (len(dokumenty), ", ".join(slova)))
+              % (pocet_dok, ", ".join(slova)))
         if chybely_text:
             print("(%d dokumentů nemělo edesky_text_url, text.gz nebyl k dispozici)" % chybely_text)
         return 0

--- a/scripts/edesky_hledej.py
+++ b/scripts/edesky_hledej.py
@@ -51,6 +51,7 @@ import urllib.error
 import xml.etree.ElementTree as ET
 
 API_URL = "https://edesky.cz/api/v1/documents"
+DASHBOARDS_URL = "https://edesky.cz/api/v1/dashboards"
 PARAM_DASHBOARD = "dashboard_id"  # v případě potřeby uprav dle apiary.apib
 TIMEOUT_S = 30
 STRANKA_VELIKOST = 200  # dle apiary.apib vrací API max 200 dokumentů na stránku
@@ -152,27 +153,55 @@ def _text(el):
     return (el.text or "").strip() if el is not None else ""
 
 
-def parsuj(xml_text):
+def parsuj(xml_text, tag_prvku="document"):
     """
     Naparsuje XML odpovědi na seznam slovníků.
 
     Parser je záměrně defenzivní — nespoléhá na přesné schéma. Z každého prvku,
-    jehož tag končí na 'document', vytáhne atributy i texty přímých potomků,
-    takže funguje, i kdyby edesky drobně změnilo strukturu.
+    jehož tag odpovídá tag_prvku (výchozí 'document', pro desky 'dashboard'),
+    vytáhne atributy i texty přímých potomků, takže funguje, i kdyby edesky
+    drobně změnilo strukturu.
     """
     root = ET.fromstring(xml_text)
-    dokumenty = []
+    polozky = []
     for el in root.iter():
         tag = el.tag.split("}")[-1].lower()  # odstraní případný namespace
-        if tag != "document":
+        if tag != tag_prvku:
             continue
-        zaznam = dict(el.attrib)  # atributy prvku <document ...>
+        zaznam = dict(el.attrib)  # atributy prvku <document .../> resp. <dashboard .../>
         for dite in el:  # texty potomků (kdyby data byla v elementech)
             k = dite.tag.split("}")[-1]
             if k not in zaznam and _text(dite):
                 zaznam[k] = _text(dite)
-        dokumenty.append(zaznam)
-    return dokumenty
+        polozky.append(zaznam)
+    return polozky
+
+
+def sestav_dashboards_url(api_key, id=None, include_subordinated=None):
+    """Sestaví URL dotazu na /api/v1/dashboards."""
+    params = {"api_key": api_key}
+    if id is not None:
+        params["id"] = id
+    if include_subordinated is not None:
+        params["include_subordinated"] = include_subordinated
+    return DASHBOARDS_URL + "?" + urllib.parse.urlencode(params)
+
+
+def stahni_desky(api_key, id=None, include_subordinated=None):
+    """
+    Stáhne seznam úředních desek z /api/v1/dashboards. Bez 'id' vrací desky
+    nejvyšší úrovně; s 'id' vrací desky podřízené té s daným id (include_subordinated=1
+    pro celou podstromovou hierarchii, ne jen přímé potomky).
+    Vrací (seznam_desek, None) při úspěchu, ([], chyba) při selhání.
+    """
+    url = sestav_dashboards_url(api_key, id, include_subordinated)
+    text, chyba = stahni(url)
+    if chyba:
+        return [], chyba
+    try:
+        return parsuj(text, tag_prvku="dashboard"), None
+    except ET.ParseError as e:
+        return [], "odpověď není platné XML (%s)" % e
 
 
 def _first(d, klice):

--- a/scripts/edesky_region_hledej.py
+++ b/scripts/edesky_region_hledej.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+edesky_region_hledej.py — fulltextově prohledá desky VŠECH obcí spadajících
+pod stejného administrativního "rodiče" (okres/ORP) jako zadaná kotevní deska.
+
+API nemá parametr "najdi mi okolí desky X" ani "najdi rodiče desky X" přímo —
+proto se rodič dohledá nepřímo: stáhne se seznam desek celého kraje
+(include_subordinated=1) a v něm se najde záznam kotevní desky, který už
+obsahuje parent_id/parent_name. Pak se seznam desek pod tímto rodičem stáhne
+znovu (include_subordinated=1) — to je hledané "okolí" — a nad každou takto
+nalezenou deskou se spustí stejné fulltextové prohledání jako v
+edesky_fulltext_hledej.py (broad-keywords = název dané obce).
+
+Použití:
+    export EDESKY_API_KEY=VAS_KLIC
+    python3 edesky_region_hledej.py \\
+        --anchor-dashboard-id 1061 \\
+        --words "Výleta,Výlety,Výletovi,Výletu,Výletou,Výletem" \\
+        --created-from 2000-01-01
+"""
+
+import argparse
+import os
+import sys
+
+from edesky_hledej import stahni_desky, _first
+from edesky_fulltext_hledej import sken_desku
+
+JIHOMORAVSKY_KRAJ_ID = 32  # zjištěno z https://edesky.cz/desky/32-Jihomoravsk%C3%BD%20kraj
+PREDPONY_NAZVU_OBCE = ("Statutární město ", "Městská část ", "MČ ", "Městys ",
+                        "Město ", "Obec ")
+
+
+def _obecny_nazev(nazev_desky):
+    """Ořeže administrativní předponu ('Obec', 'Město'...) pro použití jako broad-keywords."""
+    for predpona in PREDPONY_NAZVU_OBCE:
+        if nazev_desky.startswith(predpona):
+            nazev_desky = nazev_desky[len(predpona):]
+            break
+    return nazev_desky.split("(")[0].strip() or nazev_desky
+
+
+def najdi_rodice(anchor_id, api_key, kraj_id):
+    """Najde parent_id/parent_name kotevní desky prohledáním desek celého kraje."""
+    desky, chyba = stahni_desky(api_key, id=kraj_id, include_subordinated=1)
+    if chyba:
+        return None, None, chyba
+    anchor_id = str(anchor_id)
+    for d in desky:
+        if _first(d, ["edesky_id", "id"]) == anchor_id:
+            rodic_id = _first(d, ["parent_id"])
+            rodic_name = _first(d, ["parent_name"])
+            if not rodic_id:
+                return None, None, "kotevní deska %s nemá v datech parent_id" % anchor_id
+            return rodic_id, rodic_name, None
+    return None, None, "kotevní deska %s nenalezena mezi deskami kraje %s" % (anchor_id, kraj_id)
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        description="Fulltextové prohledání desek okolních obcí (stejný admin. rodič jako kotevní deska).")
+    p.add_argument("--api-key", default=os.environ.get("EDESKY_API_KEY"))
+    p.add_argument("--anchor-dashboard-id", default="1061",
+                   help="deska, jejíž okolí (obce se stejným rodičem) se má prohledat")
+    p.add_argument("--kraj-id", type=int, default=JIHOMORAVSKY_KRAJ_ID,
+                   help="ID kraje, ve kterém se dohledává rodič kotevní desky")
+    p.add_argument("--words", required=True,
+                   help="hledaná slova/tvary oddělené čárkou")
+    p.add_argument("--created-from", default="2000-01-01")
+    p.add_argument("--search-with", default="es", choices=["es", "sql"])
+    p.add_argument("--max-desek", type=int, default=60,
+                   help="pojistka: kolik desek okolí nejvýš prohledat")
+    args = p.parse_args(argv)
+
+    if not args.api_key:
+        p.error("chybí API klíč — zadej --api-key nebo nastav EDESKY_API_KEY")
+
+    slova = [s.strip() for s in args.words.split(",") if s.strip()]
+    if not slova:
+        p.error("--words musí obsahovat alespoň jedno slovo")
+
+    print("Hledám administrativního rodiče kotevní desky %s (v kraji %s)..." %
+          (args.anchor_dashboard_id, args.kraj_id), file=sys.stderr)
+    rodic_id, rodic_name, chyba = najdi_rodice(args.anchor_dashboard_id, args.api_key, args.kraj_id)
+    if chyba:
+        print("CHYBA: %s" % chyba, file=sys.stderr)
+        return 1
+    print("Rodič kotevní desky: %s (id=%s)\n" % (rodic_name, rodic_id), file=sys.stderr)
+
+    print("Stahuji seznam obcí spadajících pod %s..." % rodic_name, file=sys.stderr)
+    podrizene, chyba = stahni_desky(args.api_key, id=rodic_id, include_subordinated=1)
+    if chyba:
+        print("CHYBA: %s" % chyba, file=sys.stderr)
+        return 1
+
+    obce = []
+    videno = set()
+    for d in podrizene:
+        eid = _first(d, ["edesky_id", "id"])
+        nazev = _first(d, ["name"])
+        if not eid or not nazev or eid in videno:
+            continue
+        videno.add(eid)
+        obce.append((eid, nazev))
+
+    print("Nalezeno %d desek pod %s." % (len(obce), rodic_name), file=sys.stderr)
+    if len(obce) > args.max_desek:
+        print("Omezuji na prvních %d (--max-desek)." % args.max_desek, file=sys.stderr)
+        obce = obce[:args.max_desek]
+    print(file=sys.stderr)
+
+    vysledky = []
+    celkem_dokumentu = 0
+    for i, (eid, nazev) in enumerate(obce, 1):
+        broad = _obecny_nazev(nazev)
+        print("[%d/%d] %s (deska %s, broad-keywords=%r)" % (i, len(obce), nazev, eid, broad),
+              file=sys.stderr)
+        nalezeno, pocet_dok, chybely_text, chyba_seznamu = sken_desku(
+            eid, broad, slova, args.api_key, args.created_from, args.search_with,
+            stderr_prefix="  ")
+        celkem_dokumentu += pocet_dok
+        if chyba_seznamu:
+            print("    CHYBA při stahování seznamu: %s" % chyba_seznamu, file=sys.stderr)
+        print("  -> %d dokumentů prohledáno, %d shod" % (pocet_dok, len(nalezeno)), file=sys.stderr)
+        for nazev_dok, datum, url, zasahy in nalezeno:
+            vysledky.append((nazev, nazev_dok, datum, url, zasahy))
+
+    print("\n" + "=" * 60)
+    print("Prohledáno %d desek (okolí %s), celkem %d dokumentů.\n" %
+          (len(obce), rodic_name, celkem_dokumentu))
+
+    if not vysledky:
+        print("Ve fulltextu žádné z prohledaných desek nebyla nalezena shoda pro: %s"
+              % ", ".join(slova))
+        return 0
+
+    print("Nalezeno %d dokumentů se shodou:\n" % len(vysledky))
+    for deska_nazev, nazev_dok, datum, url, zasahy in vysledky:
+        print("- %s" % nazev_dok)
+        print("  deska: %s" % deska_nazev)
+        if datum:
+            print("  datum: %s" % datum)
+        if url:
+            print("  odkaz: %s" % url)
+        for slovo, useky in zasahy.items():
+            print("  shoda '%s' (%d×): …%s…" % (slovo, len(useky), useky[0]))
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- The nationwide keyword search (`search_with=es`, no dashboard filter) turned out unreliable: it returned ~73 hits, virtually all false positives on the common word "výlet" (trip), and — more importantly — missed the one document already confirmed (via manual fulltext download) to mention the target name. edesky.cz's own content index appears to have gaps/lag for at least some documents.
- Brute-forcing the working per-document fulltext scan across every municipality in the country doesn't scale (thousands of dashboards).
- This adds a middle ground: `scripts/edesky_region_hledej.py` discovers the anchor dashboard's administrative parent (okres/ORP) via the `/dashboards` endpoint, lists every dashboard under that same parent, and runs the already-working per-dashboard fulltext scan (`edesky_fulltext_hledej.sken_desku`, extracted as a reusable function) over each one.
- `scripts/edesky_hledej.py`: generalizes `parsuj()` to accept any element tag (not just `document`) so it can also parse `<dashboard>` records, and adds `stahni_desky()` / `sestav_dashboards_url()` for the `/api/v1/dashboards` endpoint.
- `.github/workflows/edesky-region-search.yml` runs it via `workflow_dispatch`.

## Test plan
- [x] `python3 scripts/edesky_hledej.py --selftest` passes
- [x] Offline unit tests: generalized `parsuj()` with `tag_prvku="dashboard"`, `_obecny_nazev()` name-prefix stripping, `najdi_rodice()` with a faked transport
- [x] All existing scripts (`edesky_fulltext_hledej`, `edesky_celostatni_hledej`, `edesky_region_hledej`) still import cleanly after the shared `parsuj()` signature change
- [ ] Run the "Edesky region search" workflow and confirm it finds the surrounding municipalities and scans their documents

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBXJZCVfw3XXR1phdVpiso)_